### PR TITLE
Configurable EC2 creations for flexibility and test purposes

### DIFF
--- a/eks.tf
+++ b/eks.tf
@@ -1,5 +1,6 @@
 module "eks-cluster" {
-  source                = "github.com/rafikbahri/tf-aws-eks?ref=2-secure-eks-cluster"
+  source                = "github.com/rafikbahri/tf-aws-eks"
+  create_cluster        = var.eks_create_cluster
   cluster_name          = "eks-cluster"
   vpc_id                = module.main-vpc.vpc_id
   vpc_cidr              = module.main-vpc.vpc_cidr_block

--- a/envs/dev.tfvars
+++ b/envs/dev.tfvars
@@ -1,3 +1,4 @@
 platform                   = "dev"
 bastion_servers_count      = 1
 etcd_cluster_servers_count = 2
+eks_create_cluster         = false

--- a/envs/dev.tfvars
+++ b/envs/dev.tfvars
@@ -1,4 +1,4 @@
 platform                   = "dev"
-bastion_servers_count      = 1
-etcd_cluster_servers_count = 2
+bastion_servers_count      = 0
+etcd_cluster_servers_count = 0
 eks_create_cluster         = false

--- a/envs/prod.tfvars
+++ b/envs/prod.tfvars
@@ -1,3 +1,4 @@
 platform                   = "prod"
 bastion_servers_count      = 0
 etcd_cluster_servers_count = 0
+eks_create_cluster         = false

--- a/envs/staging.tfvars
+++ b/envs/staging.tfvars
@@ -1,3 +1,4 @@
 platform                   = "staging"
 bastion_servers_count      = 0
 etcd_cluster_servers_count = 0
+eks_create_cluster         = false

--- a/ssh-config.tf
+++ b/ssh-config.tf
@@ -1,4 +1,5 @@
 resource "local_file" "ssh_config" {
+  count           = var.bastion_servers_count
   filename        = ".ssh/config"
   file_permission = "0644"
   content         = <<EOT

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -1,3 +1,4 @@
 platform                   = "dev"
 bastion_servers_count      = 0
 etcd_cluster_servers_count = 0
+eks_create_cluster         = false

--- a/variables.tf
+++ b/variables.tf
@@ -27,6 +27,13 @@ variable "etcd_cluster_servers_count" {
   default     = 0
 }
 
+variable "eks_create_cluster" {
+  description = "Whether to create an EKS cluster or not"
+  type        = bool
+  default     = false
+}
+
+
 variable "server_prefix" {
   description = "Instance name prefix"
   default     = "ec2"


### PR DESCRIPTION
- **Create EKS cluster variable - default to false**
- **SSH config count match to bastion count**
